### PR TITLE
Download source files

### DIFF
--- a/samples.sh
+++ b/samples.sh
@@ -20,7 +20,8 @@ fetch; echo
 cat TMP | while read i; do
   file=samples/`echo $i | cut -d/ -f1-3,6-`
   mkdir -p $(dirname $file)
-  curl "https://github.com$i" 2> /dev/null > $file
+  url="https://raw.githubusercontent.com`echo $i | sed 's/\/blob\//\//'`"
+  curl "$url" 2> /dev/null > $file
 done
 
 rm -f TMP tmp.html


### PR DESCRIPTION
I don't know if that was indented or not but the script is downloading the HTML pages instead of the source files (like https://github.com/github/linguist/blob/master/.travis.yml instead of https://raw.githubusercontent.com/github/linguist/master/.travis.yml).

These are the two lines I had to change to download the source files.
I'm opening a pull request in case that was unintended.

Thanks a lot for the script by the way! It just saved me a lot of time :smiley: 
