### PR TITLE
Improve samples.sh interface

### DIFF
--- a/samples.sh
+++ b/samples.sh
@@ -1,29 +1,32 @@
 #!/bin/bash
 
-QUERY="extension:n+NOT+slartibartfast"
+folder=$2
+query=${1// /+}
+tmp_html="$folder.html"
+tmp_txt="$folder.txt"
 > TMP
 
 fetch() {
   i=1
   while :; do
     echo -n "$i " 1>&2
-    URL="https://github.com/search?p=$i&q=$QUERY&type=Code"
-    curl "$URL" > tmp.html 2> /dev/null
-    awk -F'"' '/\/blob\// && !/#/ {print $2}' < tmp.html >> TMP
-    grep 'next_page' tmp.html > /dev/null || return
-    grep 'next_page disabled' tmp.html > /dev/null && return
+    URL="https://github.com/search?p=$i&q=$query&type=Code"
+    curl "$URL" > $tmp_html 2> /dev/null
+    awk -F'"' '/\/blob\// && !/#/ {print $2}' < $tmp_html >> $tmp_txt
+    grep 'next_page' $tmp_html > /dev/null || return
+    grep 'next_page disabled' $tmp_html > /dev/null && return
     i=$[$i + 1]
-    sleep 7
+    sleep 10
   done
 }
 
 fetch; echo
 
-cat TMP | while read i; do
-  file=samples/`echo $i | cut -d/ -f1-3,6-`
+cat $tmp_txt | while read i; do
+  file="$folder/"`echo $i | cut -d/ -f1-3,6-`
   mkdir -p $(dirname $file)
   url="https://raw.githubusercontent.com`echo $i | sed 's/\/blob\//\//'`"
   curl "$url" 2> /dev/null > $file
 done
 
-rm -f TMP tmp.html
+rm -f $tmp_txt $tmp_html

--- a/samples.sh
+++ b/samples.sh
@@ -2,15 +2,46 @@
 
 folder=$2
 query=${1// /+}
+option=""
+if [ "$#" -eq 3 ]; then
+  if [ "$3" == "new" ]; then
+    option="s=indexed&o=desc&"
+  elif [ "$3" == "old" ]; then
+    option="s=indexed&o=asc&"
+  fi
+fi
+
 tmp_html="$folder.html"
 tmp_txt="$folder.txt"
-> TMP
+> $tmp_txt
+> $tmp_html
+
+progress_bar() {
+  i=$1
+  total=$2
+  nb=$[$i * 50 / $total]
+  echo -n '['
+  for ((j=0;j<nb;j++)); do
+    echo -n '='
+  done
+  echo -n '>'
+  nb=$[49 - $nb]
+  for ((j=0;j<nb;j++)); do
+    echo -n " "
+  done
+  echo -n '] '
+  pourcentage=$[$i * 100 / $total]
+  echo -ne "$pourcentage%\r"
+}
 
 fetch() {
+  URL="https://github.com/search?${option}p=1&q=$query&type=Code"
+  curl "$URL" > $tmp_html 2> /dev/null
+  total=`grep -oP '(?<=>)[0-9]+(?=</a>\s*<a class="next_page")' $tmp_html`
   i=1
   while :; do
-    echo -n "$i " 1>&2
-    URL="https://github.com/search?p=$i&q=$query&type=Code"
+    progress_bar $i $total
+    URL="https://github.com/search?${option}p=$i&q=$query&type=Code"
     curl "$URL" > $tmp_html 2> /dev/null
     awk -F'"' '/\/blob\// && !/#/ {print $2}' < $tmp_html >> $tmp_txt
     grep 'next_page' $tmp_html > /dev/null || return
@@ -20,13 +51,22 @@ fetch() {
   done
 }
 
-fetch; echo
+echo 'Fetching search results:'
+fetch
+echo
 
-cat $tmp_txt | while read i; do
-  file="$folder/"`echo $i | cut -d/ -f1-3,6-`
+total=`wc -l < $tmp_txt`
+
+i=1
+echo 'Downloading files:'
+cat $tmp_txt | while read line; do
+  progress_bar $i $total
+  file="$folder/"`echo $line | cut -d/ -f1-3,6-`
   mkdir -p $(dirname $file)
-  url="https://raw.githubusercontent.com`echo $i | sed 's/\/blob\//\//'`"
+  url="https://raw.githubusercontent.com`echo $line | sed 's/\/blob\//\//'`"
   curl "$url" 2> /dev/null > $file
+  i=$[$i + 1]
 done
+echo
 
 rm -f $tmp_txt $tmp_html

--- a/samples.sh
+++ b/samples.sh
@@ -19,19 +19,19 @@ tmp_txt="$folder.txt"
 progress_bar() {
   i=$1
   total=$2
-  nb=$[$i * 50 / $total]
+  nb_equals=$[$i * 50 / $total]
   echo -n '['
-  for ((j=0;j<nb;j++)); do
+  j=0
+  for ((;j<nb_equals;j++)); do
     echo -n '='
   done
   echo -n '>'
-  nb=$[49 - $nb]
-  for ((j=0;j<nb;j++)); do
+  for ((;j<50;j++)); do
     echo -n " "
   done
   echo -n '] '
   pourcentage=$[$i * 100 / $total]
-  echo -ne "$pourcentage%\r"
+  echo -ne "$pourcentage% ($i)\r"
 }
 
 fetch() {


### PR DESCRIPTION
I've been using this script quite a lot lately, so I thought I could contribute back.
The input query and the output folder can now be passed as arguments (first and second arguments respectively).
The script should output something like this:

```
$ ./samples.sh "extension:cake NOT coffee" samples-test
Fetching search results:
[==================================================>] 100% (34)
Downloading files:
[===================>                               ] 39% (133)
```
